### PR TITLE
Fixed MCP3X21treating 3221 as 10-bit instead of 12

### DIFF
--- a/MCP3X21.cpp
+++ b/MCP3X21.cpp
@@ -41,11 +41,21 @@ void MCP3X21::init() {
     _i2c = &Wire;
 }
 
-uint16_t MCP3X21::read() {
+uint16_t MCP3021::read() {
     _i2c->requestFrom(_address, 2U);
 
     if (_i2c->available() == 2) {
         return ((_i2c->read() << 6) | (_i2c->read() >> 2));
+    }
+
+    return 0xFFFF;
+}
+
+uint16_t MCP3221::read() {
+    _i2c->requestFrom(_address, 2U);
+
+    if (_i2c->available() == 2) {
+        return ((_i2c->read() << 8) | _i2c->read());
     }
 
     return 0xFFFF;

--- a/MCP3X21.h
+++ b/MCP3X21.h
@@ -33,10 +33,10 @@ class MCP3X21 {
     ~MCP3X21(void);
     void init(TwoWire * i2c_obj);
     void init();
-    uint16_t toVoltage() = 0;
+    virtual uint16_t toVoltage() = 0;
 
   protected:
-    uint16_t read()=0;
+    virtual uint16_t read()=0;
     TwoWire * _i2c;
     const uint8_t _address;
     

--- a/MCP3X21.h
+++ b/MCP3X21.h
@@ -33,23 +33,29 @@ class MCP3X21 {
     ~MCP3X21(void);
     void init(TwoWire * i2c_obj);
     void init();
-    uint16_t read();
+    uint16_t toVoltage() = 0;
 
   protected:
+    uint16_t read()=0;
     TwoWire * _i2c;
     const uint8_t _address;
+    
 };
 
 class MCP3021 : public MCP3X21 {
   public:
+    uint16_t read();
     explicit MCP3021(uint8_t slave_adr = MCP3X21_DEFAULT_ADDRESS);
     uint16_t toVoltage(uint16_t data, uint32_t vref);
 };
 
 class MCP3221 : public MCP3X21 {
   public:
+    uint16_t read();
     explicit MCP3221(uint8_t slave_adr = MCP3X21_DEFAULT_ADDRESS);
     uint16_t toVoltage(uint16_t data, uint32_t vref);
 };
 
 #endif  // MCP3X21_H
+
+


### PR DESCRIPTION
Fixed the read() function where MCP3021 and MCP3221 were treated identically, with 2 bits of MCP3221 was being ignored.