### PR TITLE
Corrected scale factors and added ESP32

### DIFF
--- a/MCP3X21.cpp
+++ b/MCP3X21.cpp
@@ -66,7 +66,7 @@ MCP3021::MCP3021(uint8_t slave_adr):
 }
 
 uint16_t MCP3021::toVoltage(uint16_t data, uint32_t vref) {
-    return (vref * data / 1023);
+    return (vref * data / 1024);
 }
 
 MCP3221::MCP3221(uint8_t slave_adr):
@@ -74,5 +74,5 @@ MCP3221::MCP3221(uint8_t slave_adr):
 }
 
 uint16_t MCP3221::toVoltage(uint16_t data, uint32_t vref) {
-    return (vref * data / 4095);
+    return (vref * data / 4096);
 }

--- a/examples/MCP3021/MCP3021.ino
+++ b/examples/MCP3021/MCP3021.ino
@@ -9,7 +9,7 @@ MCP3021 mcp3021(address);
 void setup() {
     Serial.begin(115200);
 
-#if defined(ESP8266)
+#if defined(ESP8266) || defined(ESP32)
     Wire.begin(SDA, SCL);
     mcp3021.init(&Wire);
 #else

--- a/examples/MCP3221/MCP3221.ino
+++ b/examples/MCP3221/MCP3221.ino
@@ -9,7 +9,7 @@ MCP3221 mcp3221(address);
 void setup() {
     Serial.begin(115200);
 
-#if defined(ESP8266)
+#if defined(ESP8266) || defined(ESP32)
     Wire.begin(SDA, SCL);
     mcp3221.init(&Wire);
 #else


### PR DESCRIPTION
Scale factors in the toVoltage functions changed from1023 to 1024 for MCP3021 and from 4095 to 4096 for MCP3221.
Added check for ESP32 in the example MCP3021.ino.